### PR TITLE
Add examples for python/aws-kms-reencryption@v1.0, python/improper-ce…

### DIFF
--- a/src/python/rules/aws_kms_reencryption/aws_kms_reencryption.py
+++ b/src/python/rules/aws_kms_reencryption/aws_kms_reencryption.py
@@ -1,0 +1,32 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=aws-kms-reencryption@v1.0 defects=1}
+def kms_reencrypt_noncompliant():
+    import boto3
+    import base64
+    client = boto3.client('kms')
+    plaintext = client.decrypt(
+        CiphertextBlob=bytes(base64.b64decode("secret"))
+    )
+    # Noncompliant: decrypt is immediately followed by encrypt.
+    response = client.encrypt(
+        KeyId='string',
+        Plaintext=plaintext
+    )
+    return response
+# {/fact}
+
+
+# {fact rule=aws-kms-reencryption@v1.0 defects=0}
+def kms_reencrypt_compliant():
+    import boto3
+    import base64
+    client = boto3.client('kms')
+    # Compliant: server-side reencryption.
+    response = client.re_encrypt(
+        CiphertextBlob=bytes(base64.b64decode("secret")),
+        DestinationKeyId="string",
+    )
+    return response
+# {/fact}

--- a/src/python/rules/improper_certificate_validation/improper_certificate_validation.py
+++ b/src/python/rules/improper_certificate_validation/improper_certificate_validation.py
@@ -1,0 +1,37 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=improper-certificate-validation@v1.0 defects=1}
+def create_connection_noncompliant():
+    import socket
+    import ssl
+    host, port = 'example.com', 443
+    with socket.socket(socket.AF_INET) as sock:
+        context = ssl.SSLContext()
+        # Noncompliant: security certificate validation disabled.
+        context.verify_mode = ssl.CERT_NONE
+        conn = context.wrap_socket(sock, server_hostname=host)
+        try:
+            conn.connect((host, port))
+            handle(conn)
+        finally:
+            conn.close()
+# {/fact}
+
+
+# {fact rule=improper-certificate-validation@v1.0 defects=0}
+def create_connection_compliant():
+    import socket
+    import ssl
+    host, port = 'example.com', 443
+    with socket.socket(socket.AF_INET) as sock:
+        context = ssl.SSLContext()
+        # Compliant: security certificate validation enabled.
+        context.verify_mode = ssl.CERT_REQUIRED
+        conn = context.wrap_socket(sock, server_hostname=host)
+        try:
+            conn.connect((host, port))
+            handle(conn)
+        finally:
+            conn.close()
+# {/fact}

--- a/src/python/rules/improper_privilege_management/improper_privilege_management.py
+++ b/src/python/rules/improper_privilege_management/improper_privilege_management.py
@@ -1,0 +1,19 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=improper-privilege-management@v1.0 defects=1}
+def set_user_noncompliant():
+    import os
+    root = 0
+    # Noncompliant: the process user is set to root.
+    os.setuid(root)
+# {/fact}
+
+
+# {fact rule=improper-privilege-management@v1.0 defects=0}
+def set_user_compliant():
+    import os
+    root = 4
+    # Compliant: the process user is set to userid 4.
+    os.setuid(root)
+# {/fact}

--- a/src/python/rules/insecure_connection/insecure_connection.py
+++ b/src/python/rules/insecure_connection/insecure_connection.py
@@ -1,0 +1,17 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=insecure-connection@v1.0 defects=1}
+def ftp_connection_noncompliant():
+    import ftplib
+    # Noncompliant: insecure ftp used.
+    cnx = ftplib.FTP("ftp://anonymous@example.com")
+# {/fact}
+
+
+# {fact rule=insecure-connection@v1.0 defects=0}
+def ftp_connection_compliant():
+    import ftplib
+    # Compliant: secure ftp_tls used.
+    cnx = ftplib.FTP_TLS("ftp.example.com")
+# {/fact}

--- a/src/python/rules/insecure_cookie/insecure_cookie.py
+++ b/src/python/rules/insecure_cookie/insecure_cookie.py
@@ -1,0 +1,23 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=insecure-cookie@v1.0 defects=1}
+def secure_cookie_noncompliant():
+    from http.cookies import SimpleCookie
+    cookie = SimpleCookie()
+    cookie['sample'] = "sample_value"
+    # Noncompliant: the cookie is insecure.
+    cookie['sample']['secure'] = 0
+    print(cookie)
+# {/fact}
+
+
+# {fact rule=insecure-cookie@v1.0 defects=0}
+def secure_cookie_compliant():
+    from http.cookies import SimpleCookie
+    cookie = SimpleCookie()
+    cookie['sample'] = "sample_value"
+    # Compliant: the cookie is secure.
+    cookie['sample']['secure'] = True  # compliant
+    print(cookie)
+# {/fact}

--- a/src/python/rules/insecure_hashing/insecure_hashing.py
+++ b/src/python/rules/insecure_hashing/insecure_hashing.py
@@ -1,0 +1,21 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=insecure-hashing@v1.0 defects=1}
+def hashing_noncompliant():
+    import hashlib
+    from hashlib import pbkdf2_hmac
+    # Noncompliant: insecure hashing algorithm used.
+    derivedkey = hashlib.pbkdf2_hmac('sha224', password, salt, 100000)
+    derivedkey.hex()
+# {/fact}
+
+
+# {fact rule=insecure-hashing@v1.0 defects=0}
+def hashing_compliant():
+    import hashlib
+    from hashlib import pbkdf2_hmac
+    # Compliant: secure hashing algorithm used.
+    derivedkey = hashlib.pbkdf2_hmac('sha256', password, salt, 100000)
+    derivedkey.hex()
+# {/fact}


### PR DESCRIPTION
…rtificate-validation@v1.0, python/improper-privilege-management@v1.0, python/insecure-connection@v1.0, python/insecure-cookie@v1.0, python/insecure-hashing@v1.0

*Issue #, if available:*

*Description of changes:*

1. Rules Added:
         - python/aws-kms-reencryption@v1.0
	- python/improper-certificate-validation@v1.0
	- python/improper-privilege-management@v1.0
	- python/insecure-connection@v1.0
	- python/insecure-cookie@v1.0
	- python/insecure-hashing@v1.0

    

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
