### PR TITLE
Fix typo in rule name

### DIFF
--- a/src/python/rules/loose_file_permissions/loose_file_permissions.py
+++ b/src/python/rules/loose_file_permissions/loose_file_permissions.py
@@ -10,7 +10,7 @@ def change_file_permissions_noncompliant():
 # {/fact}
 
 
-# {fact rule=loose-file-permissionsn@v1.0 defects=0}
+# {fact rule=loose-file-permissions@v1.0 defects=0}
 def change_file_permissions_compliant():
     import os
     import stat


### PR DESCRIPTION
Should be `loose_file_permissions@v1.0` instead of `loose_file_permissionsn@v1.0`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
