### PR TITLE
Print summary to stdout at end of workflow

### DIFF
--- a/.github/workflows/analyze-cli.yml
+++ b/.github/workflows/analyze-cli.yml
@@ -91,11 +91,6 @@ jobs:
         path: code-guru/recommendations-summary-table.txt
         name: recommendations-summary-table.txt
 
-    - name: Print tabular summary of results to stdout
-      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
-      run: |
-        cat code-guru/recommendations-summary-table.txt
-
     - name: Find the number of the current PR
       uses: jwalton/gh-find-current-pr@v1
       id: findpr
@@ -111,3 +106,8 @@ jobs:
         # message does not seem to be displayed in comment when `path` option is used.
         message: |
           Summary of findings from CodeGuru Reviewer (more details in workflow artifacts)
+
+    - name: Print summary of results to stdout
+      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
+      run: |
+        cat code-guru/recommendations-summary-table.txt

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -106,6 +106,11 @@ jobs:
         message: |
           Summary of findings from CodeGuru Reviewer (more details in workflow artifacts)
 
+    - name: Print summary of results to stdout
+      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
+      run: |
+        cat codeguru-results-ultra-summary.txt
+
     ####### Uploading to GitHub's code scan results UX will only work once the repo is public.
 
     # - name: Upload analysis results to be shown on the GitHub Security Scans UX


### PR DESCRIPTION
* Print summary of results to stdout.
* Do it as the last step at the end of the workflow (easier to find in logs).
* Don't use columnar format anymore.