### PR TITLE
Add 'non-compliant' and 'compliant' samples for aws-missing-encryptio…

### DIFF
--- a/src/python/detectors/aws_missing_encryption_cdk/aws_missing_encryption_cdk_compliant.py
+++ b/src/python/detectors/aws_missing_encryption_cdk/aws_missing_encryption_cdk_compliant.py
@@ -1,0 +1,15 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=aws-missing-encryption-cdk@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_sqs as sqs
+
+
+class Stack(cdk.Stack):
+
+    def missing_encryption_compliant(self):
+        # Compliant: encryption present
+        encrypted_queue = sqs.Queue(self, 'encrypted_queue',
+                                    encryption=sqs.QueueEncryption.KMS_MANAGED)
+# {/fact}

--- a/src/python/detectors/aws_missing_encryption_cdk/aws_missing_encryption_cdk_noncompliant.py
+++ b/src/python/detectors/aws_missing_encryption_cdk/aws_missing_encryption_cdk_noncompliant.py
@@ -1,0 +1,14 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=aws-missing-encryption-cdk@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_sqs as sqs
+
+
+class Stack(cdk.Stack):
+
+    def missing_encryption_noncompliant(self):
+        # Noncompliant: missing encryption
+        unencrypted_queue = sqs.Queue(self, 'unencrypted_queue')
+# {/fact}

--- a/src/python/detectors/missing_authentication_for_critical_function_cdk/missing_authentication_for_critical_function_cdk_compliant.py
+++ b/src/python/detectors/missing_authentication_for_critical_function_cdk/missing_authentication_for_critical_function_cdk_compliant.py
@@ -1,0 +1,14 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=missing-authentication-for-critical-function-cdk@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+
+
+class S3Stack(cdk.Stack):
+
+    def missing_authentication_compliant(self):
+        # Compliant: bucket is private
+        public_bucket = s3.Bucket(self, 'bucket')
+# {/fact}

--- a/src/python/detectors/missing_authentication_for_critical_function_cdk/missing_authentication_for_critical_function_cdk_noncompliant.py
+++ b/src/python/detectors/missing_authentication_for_critical_function_cdk/missing_authentication_for_critical_function_cdk_noncompliant.py
@@ -1,0 +1,15 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=missing-authentication-for-critical-function-cdk@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+
+
+class S3Stack(cdk.Stack):
+
+    def missing_authentication_noncompliant(self):
+        # Noncompliant: bucket made public
+        public_bucket = s3.Bucket(self, 'bucket')
+        public_bucket.grant_public_access()
+# {/fact}


### PR DESCRIPTION
Add 'non-compliant' and 'compliant' samples for aws-missing-encryption-cdk@v1.0 and missing-authentication-for-critical-function-cdk@v1.0