### PR TITLE
Add compliant and non-compliant examples for aws-insecure-transmission-cdk, use-of-default-credentials-cdk

### DIFF
--- a/src/python/detectors/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk_compliant.py
+++ b/src/python/detectors/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk_compliant.py
@@ -1,0 +1,14 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=aws-insecure-transmission-cdk@v1.0 defects=0}
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+
+
+class BucketEnforceSSL(cdk.Stack):
+
+    def aws_insecure_transmission_cdk_compliant(self):
+        # Compliant: SSL configuration present
+        bucket = s3.Bucket(self, "s3-bucket", enforce_ssl=True)
+# {/fact}

--- a/src/python/detectors/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk_noncompliant.py
+++ b/src/python/detectors/aws_insecure_transmission_cdk/aws_insecure_transmission_cdk_noncompliant.py
@@ -1,0 +1,14 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=aws-insecure-transmission-cdk@v1.0 defects=1}
+import aws_cdk as cdk
+from aws_cdk import aws_s3 as s3
+
+
+class BucketEnforceSSL(cdk.Stack):
+
+    def aws_insecure_transmission_cdk_noncompliant(self):
+        # Noncompliant: SSL configuration missing
+        bucket = s3.Bucket(self, "s3-bucket-bad")
+# {/fact}

--- a/src/python/detectors/use_of_default_credentials_cdk/use_of_default_credentials_cdk_compliant.py
+++ b/src/python/detectors/use_of_default_credentials_cdk/use_of_default_credentials_cdk_compliant.py
@@ -1,0 +1,19 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=use-of-default-credentials-cdk@v1.0 defects=0}
+from aws_cdk import aws_redshift as redshift
+import aws_cdk as cdk
+
+
+class CdkStarterStack(cdk.Stack):
+
+    def redshift_default_username_compliant(self):
+        # Compliant: Custom username used
+        cfn_cluster = redshift.CfnCluster(self, "MyCfnCluster",
+                                          master_username='masteruser',
+                                          master_user_password='secret',
+                                          cluster_type='single-node',
+                                          db_name='bar',
+                                          node_type='ds2.xlarge')
+# {/fact}

--- a/src/python/detectors/use_of_default_credentials_cdk/use_of_default_credentials_cdk_noncompliant.py
+++ b/src/python/detectors/use_of_default_credentials_cdk/use_of_default_credentials_cdk_noncompliant.py
@@ -1,0 +1,19 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=use-of-default-credentials-cdk@v1.0 defects=1}
+from aws_cdk import aws_redshift as redshift
+import aws_cdk as cdk
+
+
+class CdkStarterStack(cdk.Stack):
+
+    def redshift_default_username_noncompliant(self):
+        # Noncompliant: Default master username used
+        cfn_cluster = redshift.CfnCluster(self, "MyCfnCluster",
+                                          master_username='awsuser',
+                                          master_user_password='secret',
+                                          cluster_type='single-node',
+                                          db_name='bar',
+                                          node_type='ds2.xlarge')
+# {/fact}


### PR DESCRIPTION
Add compliant and non-compliant examples for aws-insecure-transmission-cdk, use-of-default-credentials-cdk